### PR TITLE
moves middleware functions in server.js to middleware.json

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -1,4 +1,5 @@
 {
+  "legacyExplorer": false,
   "restApiRoot": "/api",
   "host": "0.0.0.0",
   "port": 3000,

--- a/server/middleware.json
+++ b/server/middleware.json
@@ -22,7 +22,11 @@
       ]
     }
   },
-  "files": {},
+  "files": {
+      "loopback#static": {
+      "params": "$!../client/public"
+    }
+  },
   "final": {
     "loopback#urlNotFound": {}
   },

--- a/server/middleware.json
+++ b/server/middleware.json
@@ -4,6 +4,7 @@
   },
   "initial": {
     "compression": {},
+    "express-flash": {},
     "cors": {
       "params": {
         "origin": true,
@@ -12,9 +13,29 @@
       }
     }
   },
-  "session": {},
+  "session:before": {
+    "loopback#cookieParser": {
+        "params": "${cookieSecret}"
+    }
+  },
+  "session": {
+    "loopback#session": {
+      "params": {
+        "secret": "kitty",
+        "saveUninitialized": true,
+        "resave": true
+      }
+    }
+  },
   "auth": {},
-  "parse": {},
+  "parse": {
+    "body-parser#json": {},
+    "body-parser#urlencoded": {
+      "params": {
+        "extended": true
+      }
+    }
+  },
   "routes": {
     "loopback#rest": {
       "paths": [

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -3,7 +3,7 @@
     "sources": [
       "../common/models",
       "./models",
-      "./node_modules/loopback-component-passport/lib/models"
+      "loopback-component-passport/lib/models"
     ]
   },
   "user": {

--- a/server/server.js
+++ b/server/server.js
@@ -162,21 +162,6 @@ app.get('/auth/logout', function (req, res, next) {
   res.redirect('/');
 });
 
-// -- Mount static files here--
-// All static middleware should be registered at the end, as all requests
-// passing the static middleware are hitting the file system
-// Example:
-var path = require('path');
-app.use(loopback.static(path.resolve(__dirname, '../client/public')));
-
-// Requests that get this far won't be handled
-// by any middleware. Convert them into a 404 error
-// that will be handled later down the chain.
-app.use(loopback.urlNotFound());
-
-// The ultimate error handler.
-app.use(loopback.errorHandler());
-
 app.start = function() {
 	// start the web server
 	return app.listen(function() {

--- a/server/server.js
+++ b/server/server.js
@@ -7,24 +7,6 @@ var loopbackPassport = require('loopback-component-passport');
 var PassportConfigurator = loopbackPassport.PassportConfigurator;
 var passportConfigurator = new PassportConfigurator(app);
 
-/*
- * body-parser is a piece of express middleware that
- *   reads a form's input and stores it as a javascript
- *   object accessible through `req.body`
- *
- */
-var bodyParser = require('body-parser');
-
-/**
- * Flash messages for passport
- *
- * Setting the failureFlash option to true instructs Passport to flash an
- * error message using the message given by the strategy's verify callback,
- * if any. This is often the best approach, because the verify callback
- * can make the most accurate determination of why authentication failed.
- */
-var flash      = require('express-flash');
-
 // attempt to build the providers/passport config
 var config = {};
 try {
@@ -44,29 +26,12 @@ app.set('view engine', 'jade');
 // boot scripts mount components like REST API
 boot(app, __dirname);
 
-// to support JSON-encoded bodies
-app.middleware('parse', bodyParser.json());
-// to support URL-encoded bodies
-app.middleware('parse', bodyParser.urlencoded({
-	extended: true
-}));
-
 // The access token is only available after boot
 app.middleware('auth', loopback.token({
   model: app.models.accessToken
 }));
 
-app.middleware('session:before', loopback.cookieParser(app.get('cookieSecret')));
-app.middleware('session', loopback.session({
-	secret: 'kitty',
-	saveUninitialized: true,
-	resave: true
-}));
 passportConfigurator.init();
-
-// We need flash messages to see passport errors
-app.use(flash());
-
 passportConfigurator.setupModels({
 	userModel: app.models.user,
 	userIdentityModel: app.models.userIdentity,


### PR DESCRIPTION
static page handler, error page rendering, and error handler can be configured in `middleware.json` as follows:

```
  "files": {
      "loopback#static": {
      "params": "$!../client/public"
    }
  },
  "final": {
    "loopback#urlNotFound": {}
  },
  "final:after": {
    "errorhandler": {}
  }
```

Currently, it seems that app.middleware() calls in server.js and configuration of middleware.json  is mixed.
