### PR TITLE
remove invalid route

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -93,13 +93,6 @@ app.get('/auth/account', ensureLoggedIn('/login'), function (req, res, next) {
   });
 });
 
-app.get('/link/account', ensureLoggedIn('/login'), function (req, res, next) {
-  res.render('pages/linkedAccounts', {
-    user: req.user,
-    url: req.url
-  });
-});
-
 app.get('/local', function (req, res, next){
   res.render('pages/local', {
     user: req.user,


### PR DESCRIPTION
Related issue: https://github.com/strongloop/loopback-example-passport/issues/69

I removed
```
app.get('/link/account', ensureLoggedIn('/login'), function (req, res, next) {
  res.render('pages/linkedAccounts', {
    user: req.user,
    url: req.url
  });
});
```
in `server.js`
Since the same functions are moved to [login/Profiles](https://github.com/strongloop/loopback-example-passport/blob/master/server/views/pages/loginProfiles.jade#L15-L17) after code refactor, this is no longer a valid page.

@superkhau can you review it :) thanks!